### PR TITLE
Clarify index context and prune duplicate keys

### DIFF
--- a/module1_patched.py
+++ b/module1_patched.py
@@ -292,28 +292,28 @@ def lyrics_api():
 
 @app.route("/", methods=["GET"])
 def index():
-    data = {
-        "emotions": CORE_EMOTIONS,
-        "emap": EMOTION_MAP,
-        "regions": WORLD_REGIONS,
-        "eras": ERAS,
-        "conflicts": HIGH_CONFLICTS,
-        "impact": SONG_IMPACT_TAGS,
-        "sfx": SFX,
-        "combos": SFX_COMBOS,
-        "ecompat": EMOTION_COMPAT,
-        "mpresets": MASTERING_PRESETS,
-        "mistakes": COMMON_MISTAKES,
-        "all_tags": ALL_TAGS,
-        "co_weights": CO_CLIENT,
-        "instruments": sorted(INSTRUMENT_TAGS),
-        "DEFAULT_STYLE_TAGS": DEFAULT_STYLE_TAGS,
+    """Serve the main page with all static datasets used by the frontend."""
+
+    ctx = {
+        "emotions": CORE_EMOTIONS,  # list of core emotions
+        "emotion_map": EMOTION_MAP,  # mapping: emotion -> (vocals, genres)
+        "world_regions": WORLD_REGIONS,  # regional vocal tags
+        "eras": ERAS,  # available production eras
+        "conflict_pairs": HIGH_CONFLICTS,  # incompatible vocal style pairs
+        "impact_tags": SONG_IMPACT_TAGS,  # vocal & mix impact tags
+        "sound_effects": SFX,  # available sound effect tags
+        "sfx_combos": SFX_COMBOS,  # curated sound effect combinations
+        "emotion_compatibility": EMOTION_COMPAT,  # emotion compatibility matrix
+        "mastering_presets": MASTERING_PRESETS,  # mastering suggestions
+        "common_mistakes": COMMON_MISTAKES,  # frequent user mistakes
+        "instruments": sorted(INSTRUMENT_TAGS),  # instrument tag list
+        "default_style_tags": DEFAULT_STYLE_TAGS,  # baseline style tags
     }
-    for k, v in data.items():
-        _assert_jsonable(k, v)
+    for key, value in ctx.items():
+        _assert_jsonable(key, value)
 
     print(f"[INDEX] tags={len(ALL_TAGS)} styles={len(DEFAULT_STYLE_TAGS)}")
-    return render_template("index.html", data=data)
+    return render_template("index.html", data=ctx)
 
 # ---------- MAIN ----------
 if __name__ == "__main__":

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,23 +1,23 @@
 // ---------- datasets from server ----------
 const DATA = JSON.parse(document.getElementById('app-data').textContent);
 const CORE_EMOTIONS = DATA.emotions;
-const EMOTION_MAP = DATA.emap;
-const WORLD_REGIONS = DATA.regions;
+const EMOTION_MAP = DATA.emotion_map;
+const WORLD_REGIONS = DATA.world_regions;
 const INSTRUMENT_TAGS = DATA.instruments;
 const ERAS = DATA.eras;
-const HIGH_CONFLICTS = DATA.conflicts;
-const SONG_IMPACT_TAGS = DATA.impact;
-const SFX = DATA.sfx;
-const SFX_COMBOS = DATA.combos;
-const EMOTION_COMPAT = DATA.ecompat;
-const MASTERING_PRESETS = DATA.mpresets;
-let COMMON_MISTAKES = JSON.parse(localStorage.getItem("COMMON_MISTAKES")||"null") || DATA.mistakes;
-const ALL_TAGS = DATA.all_tags || [];
+const HIGH_CONFLICTS = DATA.conflict_pairs;
+const SONG_IMPACT_TAGS = DATA.impact_tags;
+const SFX = DATA.sound_effects;
+const SFX_COMBOS = DATA.sfx_combos;
+const EMOTION_COMPAT = DATA.emotion_compatibility;
+const MASTERING_PRESETS = DATA.mastering_presets;
+let COMMON_MISTAKES = JSON.parse(localStorage.getItem("COMMON_MISTAKES")||"null") || DATA.common_mistakes;
 const CO = DATA.co_weights || {};
 const REGION_TAGS = Object.values(WORLD_REGIONS||{}).flat();
 const SFX_TAGS = Object.values(SFX||{}).flat();
 const ENGINEERING_TAGS = Object.values(SONG_IMPACT_TAGS||{}).flat();
-const DEFAULT_STYLE_TAGS = DATA.DEFAULT_STYLE_TAGS;
+const DEFAULT_STYLE_TAGS = DATA.default_style_tags;
+const ALL_TAGS = [...new Set([...DEFAULT_STYLE_TAGS, ...INSTRUMENT_TAGS, ...REGION_TAGS, ...SFX_TAGS, ...ENGINEERING_TAGS])].sort();
 
 
 // ---------- tabs ----------


### PR DESCRIPTION
## Summary
- Refactor `index` context into descriptive `ctx` dict and drop duplicated `all_tags` and `co_weights` entries
- Rename context keys for clarity and document each
- Update frontend JS to use new context structure and compute tag list client-side

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e8b6d8ba88333bbdb255dafadf9b2