### PR TITLE
Add unit tests and testing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ The application ships with JSON datasets so it can operate completely offline:
 
 These files are loaded at runtime to populate suggestions and guide the Style Builder, allowing the entire workflow to function without internet access.
 
+
+## Testing
+
+Install the test dependencies and run the suite from the project root:
+
+```bash
+pip install pytest
+pytest
+```

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+# Ensure project root is importable
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from encoder import encode_string, ZW_SEQUENCE, _glitch_tag
+
+
+def test_encode_string_inserts_zero_width_and_glitch_tag():
+    seed = "hello"
+    encoded = encode_string(seed)
+    assert encoded.startswith("hel" + ZW_SEQUENCE + "lo")
+    assert encoded.endswith(f" {ZW_SEQUENCE}[{_glitch_tag(seed)}]")
+
+
+def test_encode_string_deterministic_and_joiner():
+    text = "alpha, beta"
+    encoded1 = encode_string(text)
+    encoded2 = encode_string(text)
+    assert encoded1 == encoded2
+    assert f",{ZW_SEQUENCE} " in encoded1

--- a/tests/test_lyrics.py
+++ b/tests/test_lyrics.py
@@ -41,3 +41,7 @@ def test_lyrics_endpoint_returns_json():
     low = data["lyrics"].lower()
     assert "ancient" not in low
     assert "harmony" not in low
+
+def test_sanitize_leaves_clean_text_unchanged():
+    clean = "plain words"
+    assert sanitize_lyrics(clean) == clean

--- a/tests/test_style_builder.py
+++ b/tests/test_style_builder.py
@@ -17,3 +17,11 @@ def test_choose_excludes_from_gravity_map():
     sb = StyleBuilder(defaults, co)
     excludes = sb.choose_excludes(["rock", "metal"], [])
     assert "pop" in excludes
+
+def test_build_generates_description_and_excludes():
+    defaults = ["rock", "metal", "pop"]
+    co = {"rock": {"metal": 0.9, "pop": 0.8}, "metal": {"pop": 0.7}}
+    sb = StyleBuilder(defaults, co)
+    desc, excludes = sb.build("rock, no pop")
+    assert "rock" in desc
+    assert "pop" in excludes


### PR DESCRIPTION
## Summary
- add unit tests for encoder obfuscation, style builder build flow, and lyrics sanitization
- document how to run the test suite with pytest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e8d1b03b88333b3b497999e25ef59