### PR TITLE
Add word info lookup in LyricsEditor

### DIFF
--- a/src/components/LyricsEditor.tsx
+++ b/src/components/LyricsEditor.tsx
@@ -1,7 +1,24 @@
 import React, { useState } from 'react';
 
+// Fetch synonyms or meanings for a given word using the Datamuse API.
+// Returns an array of related words or an empty array on failure.
+export const fetchWordInfo = async (word: string): Promise<string[]> => {
+  try {
+    const response = await fetch(`https://api.datamuse.com/words?ml=${word}`);
+    if (!response.ok) {
+      throw new Error('Network response was not ok');
+    }
+    const data = await response.json();
+    return data.map((item: { word: string }) => item.word);
+  } catch (err) {
+    console.error('Failed to fetch word info:', err);
+    return [];
+  }
+};
+
 const LyricsEditor: React.FC = () => {
   const [lyrics, setLyrics] = useState('');
+  const [selectedWordInfo, setSelectedWordInfo] = useState<string[]>([]);
 
   const handleCopy = async () => {
     try {
@@ -13,11 +30,28 @@ const LyricsEditor: React.FC = () => {
 
   const handleClear = () => setLyrics('');
 
+  const handleMouseUp = async (
+    e: React.MouseEvent<HTMLTextAreaElement, MouseEvent>
+  ) => {
+    const { selectionStart, selectionEnd, value } = e.currentTarget;
+    const selected = value
+      .substring(selectionStart, selectionEnd)
+      .trim();
+    // Only fetch info if a single word is selected
+    if (selected && !/\s/.test(selected)) {
+      const info = await fetchWordInfo(selected);
+      setSelectedWordInfo(info);
+    } else {
+      setSelectedWordInfo([]);
+    }
+  };
+
   return (
     <div>
       <textarea
         value={lyrics}
         onChange={(e) => setLyrics(e.target.value)}
+        onMouseUp={handleMouseUp}
         rows={10}
         style={{ width: '100%' }}
       />
@@ -25,6 +59,13 @@ const LyricsEditor: React.FC = () => {
         <button onClick={handleCopy}>Copy</button>
         <button onClick={handleClear} style={{ marginLeft: '4px' }}>Clear</button>
       </div>
+      {selectedWordInfo.length > 0 && (
+        <ul>
+          {selectedWordInfo.map((word, index) => (
+            <li key={index}>{word}</li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- detect selected word on mouse release in LyricsEditor
- fetch related words from Datamuse API and display them
- handle network errors and empty results

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689eb60707988333a7441e063082f8bd